### PR TITLE
docs: Recommend npx pod-install for setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For iOS, use `cocoapods` to link the package.
 run the following command:
 
 ```
-$ cd ios && pod install
+$ npx pod-install
 ```
 
 For android, the package will be linked automatically on build.


### PR DESCRIPTION
# Summary

We've been recommending devs use `npx pod-install` since it will attempt to install CocoaPods CLI if it's not available on the computer (cite [React Navigation setup guide](https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project)). This has proved very useful for Expo users who are now migrating to the bare workflow and want to use community packages in their projects.

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`