### PR TITLE
Removed an unnecessary library on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,4 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
-    implementation 'org.conscrypt:conscrypt-android:2.0.0'
 }


### PR DESCRIPTION
# Overview
I don't think `conscrypt-android` is necessary. This library makes the APK size unnecessarily large.

# Test Plan
None
