### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/RNCClipboard.podspec
+++ b/RNCClipboard.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-native-community/clipboard", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,mm}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
The latest Xcode 12 fails to build when a module does not depend on `React-Core` directly. This change is necessary for all native modules on iOS. For details please see: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
1. Build an App with Xcode 11.x. Result: The app builds.
2. Build an App with Xcode 12. Result: The app will not build when depending on `React`.
3. Build an App with Xcode 12 with the PR changes applied. Result: The app builds.