### PR TITLE
feat: Expose hasString method for iOS 14+

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
+++ b/android/src/main/java/com/reactnativecommunity/clipboard/ClipboardModule.java
@@ -59,4 +59,15 @@ public class ClipboardModule extends ContextBaseJavaModule {
     ClipboardManager clipboard = getClipboardService();
     clipboard.setPrimaryClip(clipdata);
   }
+
+  @ReactMethod
+  public void hasString(Promise promise) {
+    try {
+      ClipboardManager clipboard = getClipboardService();
+      ClipData clipData = clipboard.getPrimaryClip();
+      promise.resolve(clipData != null && clipData.getItemCount() >= 1);
+    } catch (Exception e) {
+      promise.reject(e);
+    }
+  }
 }

--- a/ios/RNCClipboard.m
+++ b/ios/RNCClipboard.m
@@ -28,4 +28,19 @@ RCT_EXPORT_METHOD(getString:(RCTPromiseResolveBlock)resolve
   resolve((clipboard.string ? : @""));
 }
 
+RCT_EXPORT_METHOD(hasString:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject)
+{
+  bool stringPresent = false;
+  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
+  if (@available(iOS 10, *)) {
+    stringPresent = clipboard.hasStrings;
+  } else {
+    NSString* stringInPasteboard = clipboard.string;
+    stringPresent = stringInPasteboard != nil;
+  }
+
+  resolve([NSNumber numberWithBool: stringPresent]);
+}
+
 @end

--- a/ios/RNCClipboard.m
+++ b/ios/RNCClipboard.m
@@ -31,13 +31,13 @@ RCT_EXPORT_METHOD(getString:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(hasString:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject)
 {
-  bool stringPresent = false;
+  BOOL stringPresent = YES;
   UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
   if (@available(iOS 10, *)) {
     stringPresent = clipboard.hasStrings;
   } else {
     NSString* stringInPasteboard = clipboard.string;
-    stringPresent = stringInPasteboard != nil;
+    stringPresent = [stringInPasteboard length] == 0;
   }
 
   resolve([NSNumber numberWithBool: stringPresent]);

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -28,7 +28,7 @@ export const Clipboard = {
     NativeClipboard.setString(content);
   },
   /**
-   * Returns whether the clipborad has content or is empty. 
+   * Returns whether the clipboard has content or is empty.
    * This method returns a `Promise`, so you can use following code to get clipboard content
    * ```javascript
    * async _hasContent() {
@@ -38,5 +38,5 @@ export const Clipboard = {
    */
   hasString() {
     return NativeClipboard.hasString();
-  }
+  },
 };

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -27,4 +27,16 @@ export const Clipboard = {
   setString(content: string) {
     NativeClipboard.setString(content);
   },
+  /**
+   * Returns whether the clipborad has content or is empty. 
+   * This method returns a `Promise`, so you can use following code to get clipboard content
+   * ```javascript
+   * async _hasContent() {
+   *   var hasContent = await Clipboard.hasString();
+   * }
+   * ```
+   */
+  hasString() {
+    return NativeClipboard.hasString();
+  }
 };

--- a/src/NativeClipboard.ts
+++ b/src/NativeClipboard.ts
@@ -8,6 +8,7 @@ import {NativeModules} from 'react-native';
 //   +getConstants: () => {||};
 //   +getString: () => Promise<string>;
 //   +setString: (content: string) => void;
+//   +hasString: () => Promise<boolean>;
 // }
 
 export default NativeModules.RNCClipboard;


### PR DESCRIPTION
Firstly, thanks for the work on the clipboard!

# Overview
iOS 14 now shows a notification each time an app accesses the clipboard, so we need to be more careful on when to read it. It also has a new API that allows apps to tell if there's any content on the clipboard or not. The API has more methods than the one I implemented, I just added the one I needed. I don't have time to keep working on this unfortunately to add the rest of the methods :( I understand if you think this is not enough to merge.


# Test Plan
Unfortunately, the example project didn't compile for me, so I couldn't use that one to test, I tested directly on my own project.
To test you need an iOS 14 device and one with an older version. On both of them add a call somewhere to `await Clipboard.hasString()`. Do so while having content on the clipboard and while having an empty clipboard. You could print the result of the call to `console.log` or any other logger to see that the correct value is returned.
